### PR TITLE
Add a tooltip explaining that max value of zero means unlimited

### DIFF
--- a/elements/shipping_method_types/tiered/dashboard_form.php
+++ b/elements/shipping_method_types/tiered/dashboard_form.php
@@ -24,7 +24,7 @@ $co = Core::make('helper/lists/countries');
 <div class="row">
     <div class="col-xs-12 col-sm-6">
         <div class="form-group">
-            <?= $form->label('minimumAmount', t("Minimum Purchase Amount for this rate to apply")); ?>
+            <?= $form->label('minimumAmount', t('Minimum Purchase Amount for this rate to apply')); ?>
             <div class="input-group">
                 <div class="input-group-addon">
                     <?= Config::get('community_store.symbol'); ?>
@@ -35,7 +35,9 @@ $co = Core::make('helper/lists/countries');
     </div>
     <div class="col-xs-12 col-sm-6">
         <div class="form-group">
-            <?= $form->label('maximumAmount', t("Maximum Purchase Amount for this rate to apply")); ?>
+            <?= $form->label('maximumAmount', t('Maximum Purchase Amount for this rate to apply')); ?>
+            <i class="fa fa-question-circle launch-tooltip"
+               data-original-title="<?=t('Use a value of 0 for no limit')?>"></i>
             <div class="input-group">
                 <div class="input-group-addon">
                     <?= Config::get('community_store.symbol'); ?>

--- a/src/CommunityStore/Shipping/Method/Types/TieredShippingMethod.php
+++ b/src/CommunityStore/Shipping/Method/Types/TieredShippingMethod.php
@@ -75,7 +75,7 @@ class TieredShippingMethod extends ShippingMethodTypeMethod
 
     private function addOrUpdate($type, $data)
     {
-        if ($type == "update") {
+        if ($type === 'update') {
             $sm = $this;
         } else {
             $sm = new self();
@@ -83,8 +83,8 @@ class TieredShippingMethod extends ShippingMethodTypeMethod
         // do any saves here
         //$sm->setRate($data['rate']);
 
-        $sm->setMinimumAmount($data['minimumAmount']);
-        $sm->setMaximumAmount($data['maximumAmount']);
+        $sm->setMinimumAmount($data['minimumAmount']?:0);
+        $sm->setMaximumAmount($data['maximumAmount']?:0);
 
 
 


### PR DESCRIPTION
and avoid ugly database exception if max/min are left empty - forcing to integer 0 if they are.